### PR TITLE
product-recs-shoecarnival-api to 0.0.38

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -1,9 +1,12 @@
 dependencies:
-- name: exposecontroller
-  version: 2.3.58
+- alias: expose
+  name: exposecontroller
   repository: https://chartmuseum.build.cd.jenkins-x.io
-  alias: expose
-- name: exposecontroller
   version: 2.3.58
+- alias: cleanup
+  name: exposecontroller
   repository: https://chartmuseum.build.cd.jenkins-x.io
-  alias: cleanup
+  version: 2.3.58
+- name: product-recs-shoecarnival-api
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 0.0.38


### PR DESCRIPTION
Promote product-recs-shoecarnival-api to version 0.0.38