### PR TITLE
product-recs-shoecarnival-api to 0.0.43

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -9,4 +9,4 @@ dependencies:
   version: 2.3.58
 - name: product-recs-shoecarnival-api
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.42
+  version: 0.0.43


### PR DESCRIPTION
Promote product-recs-shoecarnival-api to version 0.0.43